### PR TITLE
Add Docker Compose Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ vcs.xml
 webResources.xml
 workspace.xml
 modules.xml
+*.swp

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,0 +1,25 @@
+FROM node:6.9.1
+MAINTAINER Paul Borrego <paul.borrego@turner.com>
+
+RUN useradd --user-group --create-home --shell /bin/false app
+
+ENV HOME=/home/app
+
+COPY package.json $HOME/cnn-hangman/
+RUN chown -R app:app $HOME/*
+
+USER app
+WORKDIR $HOME/cnn-hangman
+
+RUN npm install
+
+USER root
+COPY server.js $HOME/cnn-hangman/
+COPY routes/* $HOME/cnn-hangman/routes/
+COPY config.js $HOME/cnn-hangman/
+COPY init.js $HOME/cnn-hangman/
+
+RUN chown -R app:app $HOME/*
+USER app
+
+CMD [ "npm", "start" ]

--- a/Dockerfile.ui
+++ b/Dockerfile.ui
@@ -1,0 +1,22 @@
+FROM node:6.9.1
+MAINTAINER Paul Borrego <paul.borrego@turner.com>
+
+RUN useradd --user-group --create-home --shell /bin/false app
+
+ENV HOME=/home/app
+
+COPY package.json $HOME/cnn-hangman/
+RUN chown -R app:app $HOME/*
+
+USER app
+WORKDIR $HOME/cnn-hangman
+
+RUN npm install
+
+USER root
+COPY . $HOME/cnn-hangman/
+
+RUN chown -R app:app $HOME/*
+USER app
+
+CMD [ "npm", "run", "start:fe:dev" ]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+This is an app for playing hangman.
+
+## Getting Started (The Docker Way)
+
+```
+$ docker-compose up
+```
+
+Navigate to localhost:8080 and start playing!
+
+## Getting Started (The Non Docker Way)
+
+```
+$ npm install
+$ nvm use
+```
+
+Terminal 1
+
+```
+$ npm start
+```
+
+Terminal 2
+
+```
+$ npm run start:fe:dev
+```
+
+Navigate to localhost:8080 and start playing!

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '2'
+services:
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile.ui
+    ports:
+      - '8080:8080'
+    volumes:
+      - .:/home/app/cnn-hangman
+      - /home/app/cnn-hangman/node_modules
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile.api
+    ports:
+      - '3000:3000'
+    volumes:
+      - .:/home/app/cnn-hangman
+      - /home/app/cnn-hangman/node_modules

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "eslint": "eslint '**/*.js'",
     "start": "DEBUG=hangman* node server.js",
-    "start:fe:dev": "webpack-dev-server --hot --inline --content-base src",
+    "start:fe:dev": "webpack-dev-server --hot --inline --host 0.0.0.0 --content-base src",
     "test": "lab ./test/test.spec.js",
     "update-apply": "ncu -u",
     "update-check": "ncu"


### PR DESCRIPTION
Updates the app for developers to start up using [docker-compose](https://docs.docker.com/compose/).